### PR TITLE
Do not synchronize methods without XRay annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,13 +138,13 @@ This approach let you configure nearly everything that can be configured - at ru
 The easiest way is, to start with this example.  
 This implementation will provide static `XrayTestExecutionInfo`, but in practice you should determine these values at runtime.
 
-With this configuration Xray connector will lookup for an Jira issue of type `Test Execution` with matching attributes for:
+With this configuration, the Xray connector will lookup for a Jira issue with the following matching properties:
 
-- summary
-- description
-- revision
-- assignee
+- Type: `Test Execution`
+- Summary (title)
+- Revision
 
+If a test execution could be found, it will be reused and updated, otherwise a new one will be created.
 If you provide `null` values, the connector will ignore these fields.
 
 ```java

--- a/src/main/java/eu/tsystems/mms/tic/testerra/plugins/xray/synchronize/strategy/AdHocSyncStrategy.java
+++ b/src/main/java/eu/tsystems/mms/tic/testerra/plugins/xray/synchronize/strategy/AdHocSyncStrategy.java
@@ -66,7 +66,7 @@ public class AdHocSyncStrategy extends SyncStrategy {
             try {
                 connector.updateIssue(testExecKey, onExecutionDone);
             } catch (final JsonProcessingException e) {
-                logger.error(e.getMessage());
+                log().error(e.getMessage());
             }
         }
         connector.doTransitions(testExecKey, XrayConfig.getInstance().getTransitionsOnDone());
@@ -88,10 +88,8 @@ public class AdHocSyncStrategy extends SyncStrategy {
     }
 
     private void finishTest(MethodEndEvent event) {
-
-        final String[] testKeys = getTestKeys(event);
-
-        if (testKeys != null) {
+        getTestKeysFromAnnotation(event).ifPresent(testKeys -> {
+            log().info("Synchronize: " + String.join(", ", testKeys));
             for (final String testKey : testKeys) {
 
                 final ITestResult testResult = event.getTestResult();
@@ -103,11 +101,11 @@ public class AdHocSyncStrategy extends SyncStrategy {
                 try {
                     connector.syncTestExecutionReturnKey(testExecution);
                 } catch (final IOException e) {
-                    logger.error(e.getMessage());
+                    log().error(e.getMessage());
                 }
                 connector.updateFinishTimeOfTestExecution(testExecKey);
             }
-        }
+        });
     }
 
 }

--- a/src/main/java/eu/tsystems/mms/tic/testerra/plugins/xray/synchronize/strategy/PostHocSyncStrategy.java
+++ b/src/main/java/eu/tsystems/mms/tic/testerra/plugins/xray/synchronize/strategy/PostHocSyncStrategy.java
@@ -39,7 +39,6 @@ import java.io.IOException;
 import java.util.Set;
 import org.testng.ITestResult;
 
-
 public class PostHocSyncStrategy extends SyncStrategy {
 
     private XrayTestExecution testExecution;
@@ -49,7 +48,6 @@ public class PostHocSyncStrategy extends SyncStrategy {
 
     public PostHocSyncStrategy(XrayInfo xrayInfo, XrayMapper xrayMapper, XrayTestExecutionUpdates updates) {
         super(xrayInfo, xrayMapper, updates);
-        logger.info("calling constructor");
     }
 
     @Override
@@ -72,7 +70,7 @@ public class PostHocSyncStrategy extends SyncStrategy {
                 throw new NotSyncableException(message);
             }
         } catch (IOException e) {
-            logger.error(e.getMessage());
+            log().error(e.getMessage());
         }
 
     }
@@ -109,7 +107,7 @@ public class PostHocSyncStrategy extends SyncStrategy {
             connector.doTransitions(testExecKey, XrayConfig.getInstance().getTransitionsOnDone());
             connector.updateFinishTimeOfTestExecution(testExecKey);
         } catch (IOException e) {
-            logger.error(e.getMessage());
+            log().error(e.getMessage());
         }
     }
 
@@ -130,13 +128,12 @@ public class PostHocSyncStrategy extends SyncStrategy {
 
     private void finishTest(MethodEndEvent event) {
         final ITestResult result = event.getTestResult();
-        final String[] testKeys = getTestKeys(event);
-
-        if (testKeys != null) {
+        getTestKeysFromAnnotation(event).ifPresent(testKeys -> {
+            log().info("Synchronize: " + String.join(", ", testKeys));
             for (final String testKey : testKeys) {
                 final XrayTestIssue xrayTestIssue = createXrayTestIssue(testKey, result);
                 tests.add(xrayTestIssue);
             }
-        }
+        });
     }
 }


### PR DESCRIPTION
# Description

This change prevents error logs, when a method is beeing synchronized which even doesn't have an `XRayTest` annotation.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
