### PR TITLE
Added access token authentication (Bearer token)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,14 @@ xray.sync.strategy=adhoc
 # Connection details (mandatory)
 xray.rest.service.uri=https://jira.example.com/rest
 xray.project.key=PROJECT-KEY
+
+# Xray connector supports Token based authentication or basic authentication
+# If no token is defined, Xray connector uses 'user/password'
+xray.token=jiratoken
+# or
 xray.user=jira-sync-user
 xray.password=password
+
 
 # Jira field IDs (mandatory)
 xray.test.execution.start.time.field.id=

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,6 @@ apply plugin: 'io.codearte.nexus-staging'
 
 ext {
     // Minimum required Testerra version
-//    testerraCompileVersion = '1.4-SNAPSHOT'
     testerraCompileVersion = '1.0.0'
     // Unit tests use the latest Testerra version
     testerraTestVersion = '[1.0-RC,2-SNAPSHOT)'

--- a/src/main/java/eu/tsystems/mms/tic/testerra/plugins/xray/config/XrayConfig.java
+++ b/src/main/java/eu/tsystems/mms/tic/testerra/plugins/xray/config/XrayConfig.java
@@ -30,10 +30,12 @@ import eu.tsystems.mms.tic.testerra.plugins.xray.synchronize.strategy.PostHocSyn
 import eu.tsystems.mms.tic.testerra.plugins.xray.synchronize.strategy.SyncStrategy;
 import eu.tsystems.mms.tic.testframework.common.PropertyManager;
 import eu.tsystems.mms.tic.testframework.exceptions.SetupException;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,6 +56,7 @@ public class XrayConfig {
     private final List<String> transitionsOnCreated;
     private final List<String> transitionsOnUpdated;
     private final String password;
+    private final String token;
     private final boolean webResourceFilterLoggingEnabled;
     private final boolean webResourceFilterGetRequestsOnlyEnabled;
     private final boolean isSyncSkippedTests;
@@ -67,6 +70,7 @@ public class XrayConfig {
         projectKey = PropertyManager.getProperty("xray.project.key");
         username = PropertyManager.getProperty("xray.user");
         password = PropertyManager.getProperty("xray.password");
+        token = PropertyManager.getProperty("xray.token");
 
         isSyncEnabled = PropertyManager.getBooleanProperty("xray.sync.enabled", false);
         isSyncSkippedTests = PropertyManager.getBooleanProperty("xray.sync.skipped", false);
@@ -94,7 +98,7 @@ public class XrayConfig {
         fakeTestExecutionKey = PropertyManager.getProperty("xray.webresource.filter.getrequestsonly.fake.response.key", "FAKE-666666");
 
         previousResultsFilename = PropertyManager.getProperty("xray.previous.result.filename", "");
-        
+
         /**
          * @todo Replace by field validation {@link Field#getValidationRegex()}
          */
@@ -230,6 +234,10 @@ public class XrayConfig {
         return password;
     }
 
+    public String getToken() {
+        return token;
+    }
+
     /**
      * @deprecated Logging is handled by Log4J configuration
      */
@@ -253,7 +261,6 @@ public class XrayConfig {
     public boolean isSyncSkippedTests() {
         return isSyncSkippedTests;
     }
-
 
     /**
      * @deprecated Use {@link Fields} instead

--- a/src/main/java/eu/tsystems/mms/tic/testerra/plugins/xray/connect/HttpBearerTokenAuthFilter.java
+++ b/src/main/java/eu/tsystems/mms/tic/testerra/plugins/xray/connect/HttpBearerTokenAuthFilter.java
@@ -1,0 +1,45 @@
+/*
+ * Testerra Xray-Connector
+ *
+ * (C) 2021, Martin Großmann, T-Systems Multimedia Solutions GmbH, Deutsche Telekom AG
+ *
+ * Deutsche Telekom AG and all other contributors /
+ * copyright owners license this file to you under the Apache
+ * License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package eu.tsystems.mms.tic.testerra.plugins.xray.connect;
+
+import com.sun.jersey.api.client.ClientHandlerException;
+import com.sun.jersey.api.client.ClientRequest;
+import com.sun.jersey.api.client.ClientResponse;
+import com.sun.jersey.api.client.filter.ClientFilter;
+
+public class HttpBearerTokenAuthFilter extends ClientFilter {
+
+    private final String authentication;
+
+    public HttpBearerTokenAuthFilter(String token) {
+        this.authentication = "Bearer " + token;
+    }
+
+    public ClientResponse handle(ClientRequest cr) throws ClientHandlerException {
+        if (!cr.getHeaders().containsKey("Authorization")) {
+            cr.getHeaders().add("Authorization", this.authentication);
+        }
+
+        return this.getNext().handle(cr);
+    }
+}

--- a/src/main/java/eu/tsystems/mms/tic/testerra/plugins/xray/connect/XrayConnector.java
+++ b/src/main/java/eu/tsystems/mms/tic/testerra/plugins/xray/connect/XrayConnector.java
@@ -88,10 +88,10 @@ public class XrayConnector {
 
         if (StringUtils.isNotEmpty(xrayConfig.getToken())) {
             logger.info("Use Bearer token authentication");
-            webResource.addFilter(new HTTPBasicAuthFilter(xrayConfig.getUsername(), xrayConfig.getPassword()));
+            webResource.addFilter(new HttpBearerTokenAuthFilter(xrayConfig.getToken()));
         } else {
             logger.info("Use Basic authentication");
-            webResource.addFilter(new HttpBearerTokenAuthFilter(xrayConfig.getToken()));
+            webResource.addFilter(new HTTPBasicAuthFilter(xrayConfig.getUsername(), xrayConfig.getPassword()));
         }
 
         if (xrayConfig.isWebResourceFilterGetRequestsOnlyEnabled()) {


### PR DESCRIPTION
# Description

Jira also allows to create an access token for using REST API. This change adds the support to use a token instead of user and password with the new property `xray.token`.
If this property is defined, Xray connector tries to login with that token. If its not defined, Xray connector uses basic authentication with user and password.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
