### PR TITLE
Fixed test step result sync, made it independent from updating test issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,11 @@ A list of other mapping implementations.
 
 #### DefaultSummaryMapper
 
-This maps Java test methods to Jira *Tests* and Java classes to Jira *Test Sets* by their name, when no keys are present in the annotations. Additionally, it creates the issues when they don't exist. You enable that feature by passing that mapper in your `XrayResultsSynchronizer`.
+This maps Java test methods to Jira *Tests* and Java classes to Jira *Test Sets* by their name, when no keys are present in the annotations. 
+
+Please note, that this mapper creates the issues when they don't exist! See above for more details how it's work.
+
+You enable that feature by passing that mapper in your `XrayResultsSynchronizer`.
 
 ```java
 public class MyXrayResultsSynchronizer extends AbstractXrayResultsSynchronizer {
@@ -227,36 +231,11 @@ Please note, that
 - `queryTest` is also called if you use `@XrayTest` annotation, but without key attribute
 - `queryTestSet` is also called if you `@XrayTestSet` annotation, but without key attribute
 
-#### Update entities
-
-The `XrayMapper` also provides callbacks for updating entities.
-
-```java
-public class GenericMapper implements XrayMapper {
-    
-    @Override
-    public void updateTestExecution(XrayTestExecutionIssue xrayTestExecutionIssue, ExecutionContext executionContext) {
-        xrayTestExecutionIssue.getTestEnvironments().add("Test");
-        xrayTestExecutionIssue.setFixVersions(List.of(new JiraNameReference("1.0")));
-    }
-
-    @Override
-    public void updateTestSet(XrayTestSetIssue xrayTestSetIssue, ClassContext classContext) {
-        xrayTestSetIssue.getLabels().add("TestAutomation");
-    }
-
-    @Override
-    public void updateTest(XrayTestIssue xrayTestIssue, MethodContext methodContext) {
-        xrayTestIssue.getLabels().add("TestAutomation");
-    }
-}
-```
-
-You can use these methods to update the Jira issues right before importing. Please mind, that not all features are supported by the [Xray import API](#references).
-
 #### Creating new entities
 
 By default, the Xray connector doesn't create any issues. You can enable that by passing `true` in the interface.
+
+Please note, that existing issues will be updated automatically. All manual changes like test steps will be overwritten.
 
 ```java
 public class GenericMapper implements XrayMapper {
@@ -281,6 +260,33 @@ public class GenericMapper implements XrayMapper {
 If you create new test issues, Xray connector will use the method `getDefaultTestIssueSummery` for generate new issue summary.
 
 In the example above new created test issues get the summery according the format `<TestClass_TestMethod>` like `MyTestClass_testSomething`. 
+
+#### Updating existing entities
+
+The `XrayMapper` also provides callbacks for updating entities. To use these callbacks you have to allow to create new issues (see [Creating new entities](#creating new entities)).
+
+```java
+public class GenericMapper implements XrayMapper {
+    
+    @Override
+    public void updateTestExecution(XrayTestExecutionIssue xrayTestExecutionIssue, ExecutionContext executionContext) {
+        xrayTestExecutionIssue.getTestEnvironments().add("Test");
+        xrayTestExecutionIssue.setFixVersions(List.of(new JiraNameReference("1.0")));
+    }
+
+    @Override
+    public void updateTestSet(XrayTestSetIssue xrayTestSetIssue, ClassContext classContext) {
+        xrayTestSetIssue.getLabels().add("TestAutomation");
+    }
+
+    @Override
+    public void updateTest(XrayTestIssue xrayTestIssue, MethodContext methodContext) {
+        xrayTestIssue.getLabels().add("TestAutomation");
+    }
+}
+```
+
+You can use these methods to update the Jira issues right before importing. Please mind, that not all features are supported by the [Xray import API](#references).
 
 #### How to use JqlQuery
 

--- a/README.md
+++ b/README.md
@@ -263,7 +263,9 @@ In the example above new created test issues get the summery according the forma
 
 #### Updating existing entities
 
-The `XrayMapper` also provides callbacks for updating entities. To use these callbacks you have to allow to create new issues (see [Creating new entities](#creating-new-entities)).
+The `XrayMapper` also provides callbacks for updating entities. 
+
+To update Xray testsets and test issues you have to allow to create new issues (see [Creating new entities](#creating-new-entities)).
 
 ```java
 public class GenericMapper implements XrayMapper {

--- a/README.md
+++ b/README.md
@@ -257,15 +257,15 @@ public class GenericMapper implements XrayMapper {
 }
 ```
 
-If you create new test issues, Xray connector will use the method `getDefaultTestIssueSummery` for generate new issue summary.
+If you create new test issues, Xray connector will use the method `getDefaultTestIssueSummery` to generate a new issue summary.
 
-In the example above new created test issues get the summery according the format `<TestClass_TestMethod>` like `MyTestClass_testSomething`. 
+In the example above new created test issues get the summary according to the format `<TestClass_TestMethod>` , e.g. `MyTestClass_testSomething`. 
 
 #### Updating existing entities
 
 The `XrayMapper` also provides callbacks for updating entities. 
 
-To update Xray testsets and test issues you have to allow to create new issues (see [Creating new entities](#creating-new-entities)).
+To update Xray testsets and test issues you have to allow creating new issues (see [Creating new entities](#creating-new-entities)).
 
 ```java
 public class GenericMapper implements XrayMapper {

--- a/README.md
+++ b/README.md
@@ -398,9 +398,9 @@ You can retrieve these IDs directly from a Jira by **editing** an Xray **Test Ex
 |xray.webresource.filter.getrequestsonly.enabled|false|Enable this for debugging to avoid PUT/POST/DELETE requests sent to Jira|
 |xray.webresource.filter.getrequestsonly.fake.response.key|FAKE-666666|This key will returned, when `xray.webresource.filter.getrequestsonly.enabled` set to `true` and PUT/POST/DELETE request was sent.|
 
----
+## Additional information
 
-## Troubleshooting
+### Troubleshooting
 
 Hints for the following occuring symptoms:
 
@@ -408,6 +408,23 @@ Symptom | Explanation | Solution
 --- | --- | ---
 `{"error": "...java.sql.SQLIntegrityConstraintViolationException: ORA-00001: unique constraint (JIRA_SCHEMA.SYS_C00134897) violated` | An issue could not be imported because it already exists. | Make sure that the issue key for an existing issue could be found via. the `query()` methods of the `XrayMapper`.
 `{"errorMessages":["We can't create this issue for you right now, it could be due to unsupported content you've entered into one or more of the issue fields...` | Missing data on the issue. | Try to create an issue manually, call the REST API for this issue and check which fields are set by default. |
+
+
+### References
+
+1. Import Xray results: https://docs.getxray.app/display/XRAY/Import+Execution+Results
+2. Xray JSON import format: https://docs.getxray.app/display/XRAY/Import+Execution+Results#ImportExecutionResults-XrayJSONformat
+3. Jira REST API: https://developer.atlassian.com/server/jira/platform/jira-rest-api-examples/
+
+### Known issues
+
+1. Adding labels for a new Test execution will be ignored because it is not supported by Xray JSON import format.
+2. Using ``DefaultSummeryMapper`` and __identical__ test method names:
+ * The xray connector could create issues with identical summaries and can sync the results.
+ * On the second run Xray connector find existing issue with the given summary = method name. Xray connector uses the first find, it cannot distinguish the other issues with the same summary to the correct Xray issues.
+ * Please note, that in that case the sync is not working as expected. Please extend the mapping, e.g. <classname_methodname>
+
+---
 
 ## Publication
 
@@ -429,15 +446,6 @@ If all properties are set, call the following to build, deploy and release this 
 ````shell
 gradle publish closeAndReleaseRepository
 ````
-
-## References
-
-1. Import Xray results: https://docs.getxray.app/display/XRAY/Import+Execution+Results
-2. Xray JSON import format: https://docs.getxray.app/display/XRAY/Import+Execution+Results#ImportExecutionResults-XrayJSONformat
-
-## Known issues
-
-1. Adding labels for a new Test execution will be ignored because it is not supported by Xray JSON import format. 
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -433,6 +433,11 @@ gradle publish closeAndReleaseRepository
 ## References
 
 1. Import Xray results: https://docs.getxray.app/display/XRAY/Import+Execution+Results
+2. Xray JSON import format: https://docs.getxray.app/display/XRAY/Import+Execution+Results#ImportExecutionResults-XrayJSONformat
+
+## Known issues
+
+1. Adding labels for a new Test execution will be ignored because it is not supported by Xray JSON import format. 
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ In the example above new created test issues get the summery according the forma
 
 #### Updating existing entities
 
-The `XrayMapper` also provides callbacks for updating entities. To use these callbacks you have to allow to create new issues (see [Creating new entities](#creating new entities)).
+The `XrayMapper` also provides callbacks for updating entities. To use these callbacks you have to allow to create new issues (see [Creating new entities](#creating-new-entities)).
 
 ```java
 public class GenericMapper implements XrayMapper {

--- a/src/main/java/eu/tsystems/mms/tic/testerra/plugins/xray/mapper/jira/JiraError.java
+++ b/src/main/java/eu/tsystems/mms/tic/testerra/plugins/xray/mapper/jira/JiraError.java
@@ -1,0 +1,30 @@
+package eu.tsystems.mms.tic.testerra.plugins.xray.mapper.jira;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Created on 2022-10-11
+ *
+ * @author mgn
+ */
+public class JiraError {
+
+    private String[] messages;
+
+    private String summary;
+
+    private String project;
+
+    public List<String> getMessages() {
+        return Arrays.asList(messages);
+    }
+
+    public String getSummary() {
+        return summary;
+    }
+
+    public String getProject() {
+        return project;
+    }
+}

--- a/src/main/java/eu/tsystems/mms/tic/testerra/plugins/xray/mapper/jira/JiraError.java
+++ b/src/main/java/eu/tsystems/mms/tic/testerra/plugins/xray/mapper/jira/JiraError.java
@@ -1,3 +1,24 @@
+/*
+ * Testerra Xray-Connector
+ *
+ * (C) 2022, Martin Großmann, T-Systems Multimedia Solutions GmbH, Deutsche Telekom AG
+ *
+ * Deutsche Telekom AG and all other contributors /
+ * copyright owners license this file to you under the Apache
+ * License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
 package eu.tsystems.mms.tic.testerra.plugins.xray.mapper.jira;
 
 import java.util.Arrays;
@@ -11,9 +32,7 @@ import java.util.List;
 public class JiraError {
 
     private String[] messages;
-
     private String summary;
-
     private String project;
 
     public List<String> getMessages() {

--- a/src/main/java/eu/tsystems/mms/tic/testerra/plugins/xray/mapper/xray/XrayTestExecutionImport.java
+++ b/src/main/java/eu/tsystems/mms/tic/testerra/plugins/xray/mapper/xray/XrayTestExecutionImport.java
@@ -23,6 +23,7 @@ package eu.tsystems.mms.tic.testerra.plugins.xray.mapper.xray;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import eu.tsystems.mms.tic.testerra.plugins.xray.jql.predefined.TestType;
+import eu.tsystems.mms.tic.testerra.plugins.xray.mapper.jira.JiraError;
 import eu.tsystems.mms.tic.testerra.plugins.xray.mapper.jira.JiraIssue;
 import eu.tsystems.mms.tic.testerra.plugins.xray.mapper.jira.JiraKeyReference;
 import eu.tsystems.mms.tic.testerra.plugins.xray.mapper.jira.JiraNameReference;
@@ -91,13 +92,19 @@ public class XrayTestExecutionImport {
 
     public static class ResultTestIssueImport {
 
-        private JiraKeyReference[] success;
+        private JiraKeyReference[] success = {};
+
+        private JiraError[] error = {};
 
         public ResultTestIssueImport() {
         }
 
         public List<JiraKeyReference> getSuccess() {
             return Arrays.asList(success);
+        }
+
+        public List<JiraError> getError() {
+            return Arrays.asList(this.error);
         }
     }
 
@@ -324,19 +331,8 @@ public class XrayTestExecutionImport {
         private Status status;
         private List<Step> steps;
 
-        public TestRun() {
-        }
-
-        public TestRun(JiraIssue issue) {
-            this(issue.getKey());
-            this.testInfo = new Info();
-            this.testInfo.setDescription(issue.getDescription());
-            this.testInfo.setSummary(issue.getSummary());
-            this.testInfo.setLabels(issue.getLabels());
-            this.testInfo.setDefinition(issue.getSummary());
-            this.testInfo.setType(TestType.AutomatedGeneric);
-            this.testInfo.setProjectKey(issue.getProject().getKey());
-        }
+//        public TestRun() {
+//        }
 
         public TestRun(String testKey) {
             this.testKey = testKey;

--- a/src/main/java/eu/tsystems/mms/tic/testerra/plugins/xray/mapper/xray/XrayTestExecutionImport.java
+++ b/src/main/java/eu/tsystems/mms/tic/testerra/plugins/xray/mapper/xray/XrayTestExecutionImport.java
@@ -331,8 +331,8 @@ public class XrayTestExecutionImport {
         private Status status;
         private List<Step> steps;
 
-//        public TestRun() {
-//        }
+        public TestRun() {
+        }
 
         public TestRun(String testKey) {
             this.testKey = testKey;

--- a/src/main/java/eu/tsystems/mms/tic/testerra/plugins/xray/synchronize/AbstractXrayResultsSynchronizer.java
+++ b/src/main/java/eu/tsystems/mms/tic/testerra/plugins/xray/synchronize/AbstractXrayResultsSynchronizer.java
@@ -404,7 +404,7 @@ public abstract class AbstractXrayResultsSynchronizer implements XrayResultsSync
                 importTestStep.setAction(testerraTestStep.getName());
                 // We always expect the step to pass
                 importTestStep.setResult(XrayTestExecutionImport.TestRun.Status.PASS.toString());
-                testRun.getTestInfo().addStep(importTestStep);
+                info.addStep(importTestStep);
             }
 
             testRun.setTestInfo(info);

--- a/src/main/java/eu/tsystems/mms/tic/testerra/plugins/xray/synchronize/AbstractXrayResultsSynchronizer.java
+++ b/src/main/java/eu/tsystems/mms/tic/testerra/plugins/xray/synchronize/AbstractXrayResultsSynchronizer.java
@@ -361,11 +361,7 @@ public abstract class AbstractXrayResultsSynchronizer implements XrayResultsSync
          */
         currentTestIssues.stream()
                 .peek(issue -> xrayMapper.updateTest(issue, methodContext))
-                .map(issue -> {
-                    XrayTestExecutionImport.TestRun run = new XrayTestExecutionImport.TestRun(issue.getKey());
-                    this.updateTestInfoForImport(run, issue, methodContext);
-                    return run;
-                })
+                .map(issue -> this.updateTestInfoForImport(issue, methodContext))
                 .peek(testRun -> updateTestRunForImport(testRun, methodContext))
                 .forEach(testRunSyncQueue::add);
 
@@ -378,7 +374,8 @@ public abstract class AbstractXrayResultsSynchronizer implements XrayResultsSync
      * Update the Info object for creating or updating Xray tests.
      * If no Info object is defined, the Xray test will not be updated.
      */
-    private void updateTestInfoForImport(XrayTestExecutionImport.TestRun testRun, XrayTestIssue issue, MethodContext methodContext) {
+    private XrayTestExecutionImport.TestRun updateTestInfoForImport(XrayTestIssue issue, MethodContext methodContext) {
+        XrayTestExecutionImport.TestRun testRun = new XrayTestExecutionImport.TestRun(issue.getKey());
         if (this.getXrayMapper().shouldCreateNewTest(methodContext)) {
 
             XrayTestExecutionImport.TestRun.Info info = new XrayTestExecutionImport.TestRun.Info();
@@ -388,7 +385,6 @@ public abstract class AbstractXrayResultsSynchronizer implements XrayResultsSync
             info.setDefinition(issue.getSummary());
             info.setType(TestType.AutomatedGeneric);
             info.setProjectKey(issue.getProject().getKey());
-
 
             // The test's test type needs to be {@link TestType.Manual} to support test steps.
             info.setType(TestType.Manual);
@@ -410,6 +406,7 @@ public abstract class AbstractXrayResultsSynchronizer implements XrayResultsSync
 
             testRun.setTestInfo(info);
         }
+        return testRun;
     }
 
     /**

--- a/src/main/java/eu/tsystems/mms/tic/testerra/plugins/xray/synchronize/XrayMapper.java
+++ b/src/main/java/eu/tsystems/mms/tic/testerra/plugins/xray/synchronize/XrayMapper.java
@@ -69,7 +69,9 @@ public interface XrayMapper {
     }
 
     /**
-     * If true, try to create a Xray Test
+     * If true, try to create or update a Xray Test
+     * <p>
+     * The create/update process includes issue attributes and test steps.
      */
     default boolean shouldCreateNewTest(MethodContext methodContext) {
         return false;
@@ -133,8 +135,6 @@ public interface XrayMapper {
 
     /**
      * Returns the default test issue summery for creating new tests or searching for mapping
-     * @param methodContext
-     * @return
      */
     default String getDefaultTestIssueSummery(MethodContext methodContext) {
         return methodContext.getName();


### PR DESCRIPTION
# Description

Syncing test results to test steps is now independent from creating or updating Xray test issues.

If test steps defined in your Testerra test, Xray connector try to sync the results to existing test issue steps in Xray.

Using the `DefaultSummaryMapper` means that Xray test issues are updated. Also existing test steps will be overwritten by Testerra test steps.

Fixes #16 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
