### PR TITLE
Changed DefaultSummaryMapper flag for new/update tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ Please note, that
 
 By default, the Xray connector doesn't create any issues. You can enable that by passing `true` in the interface.
 
-Please note, that existing issues will be updated automatically. All manual changes like test steps will be overwritten.
+Please note, that already existing issues will be updated automatically. All manual changes like test steps in a Xray test will be overwritten!
 
 ```java
 public class GenericMapper implements XrayMapper {

--- a/README.md
+++ b/README.md
@@ -229,9 +229,9 @@ public class MyXrayResultsSynchronizer extends AbstractXrayResultsSynchronizer {
 
 This maps Java test methods to Jira *Tests* and Java classes to Jira *Test Sets* by their name, when no keys are present in the annotations. 
 
-Please note, that this mapper creates the issues when they don't exist! See above for more details how it's work.
+Please note, that a test method will not be synchronized if Xray connector has not found a Xray test with the name of the test method (see also [Creating new entities](#creating-new-entities)).  
 
-You enable that feature by passing that mapper in your `XrayResultsSynchronizer`.
+Activate this mapper by passing `DefaultSummaryMapper` in your `XrayResultsSynchronizer`:
 
 ```java
 public class MyXrayResultsSynchronizer extends AbstractXrayResultsSynchronizer {

--- a/src/main/java/eu/tsystems/mms/tic/testerra/plugins/xray/synchronize/DefaultSummaryMapper.java
+++ b/src/main/java/eu/tsystems/mms/tic/testerra/plugins/xray/synchronize/DefaultSummaryMapper.java
@@ -25,7 +25,7 @@ public class DefaultSummaryMapper implements XrayMapper {
 
     @Override
     public boolean shouldCreateNewTest(MethodContext methodContext) {
-        return true;
+        return false;
     }
 
     @Override


### PR DESCRIPTION
# Description

This PR changes the default behaviour of `DefaultSummeryMapper`: 

Creating or updating new Xray tests is now deactivated by default. The update of an Xray test also overwrites existing test steps. This could be an unexpected behaviour.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
