### PR TITLE
Check for null values when loading the Xray properties

### DIFF
--- a/src/main/java/eu/tsystems/mms/tic/testerra/plugins/xray/config/XrayConfig.java
+++ b/src/main/java/eu/tsystems/mms/tic/testerra/plugins/xray/config/XrayConfig.java
@@ -25,6 +25,7 @@ package eu.tsystems.mms.tic.testerra.plugins.xray.config;
 import eu.tsystems.mms.tic.testerra.plugins.xray.mapper.Field;
 import eu.tsystems.mms.tic.testframework.common.PropertyManager;
 import eu.tsystems.mms.tic.testframework.logging.Loggable;
+import org.apache.commons.lang3.StringUtils;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -59,10 +60,15 @@ public class XrayConfig implements Loggable {
 
         URI uri = null;
         final String baseUriProperty = "xray.rest.service.uri";
-        try {
-            uri = new URI(PropertyManager.getProperty(baseUriProperty));
-        } catch (final URISyntaxException e) {
-            log().error(String.format("Unable to parse property %s", baseUriProperty), e);
+        String baseURI = PropertyManager.getProperty(baseUriProperty);
+        if (StringUtils.isNotBlank(baseURI)) {
+            try {
+                uri = new URI(baseURI);
+            } catch (final URISyntaxException e) {
+                log().error(String.format("Unable to parse property %s", baseUriProperty), e);
+            }
+        } else {
+            log().error(String.format("Xray REST URI property %s is not defined", baseUriProperty));
         }
         restServiceUri = uri;
         webResourceFilterLoggingEnabled = PropertyManager.getBooleanProperty("xray.webresource.filter.logging.enabled", false);
@@ -150,6 +156,9 @@ public class XrayConfig implements Loggable {
     }
 
     public Optional<URI> getIssueUrl(String issueKey) {
+        if (restServiceUri == null) {
+            return Optional.empty();
+        }
         URI url = null;
         try {
             url = new URI(restServiceUri.getScheme(), restServiceUri.getUserInfo(), restServiceUri.getHost(), restServiceUri.getPort(), String.format("/browse/%s", issueKey), null, null);

--- a/src/main/java/eu/tsystems/mms/tic/testerra/plugins/xray/config/XrayConfig.java
+++ b/src/main/java/eu/tsystems/mms/tic/testerra/plugins/xray/config/XrayConfig.java
@@ -65,10 +65,10 @@ public class XrayConfig implements Loggable {
             try {
                 uri = new URI(baseURI);
             } catch (final URISyntaxException e) {
-                log().error(String.format("Unable to parse property %s", baseUriProperty), e);
+                log().error("Unable to parse property {}", baseUriProperty, e);
             }
         } else {
-            log().error(String.format("Xray REST URI property %s is not defined", baseUriProperty));
+            log().error("Xray REST URI property {} is not defined", baseUriProperty);
         }
         restServiceUri = uri;
         webResourceFilterLoggingEnabled = PropertyManager.getBooleanProperty("xray.webresource.filter.logging.enabled", false);


### PR DESCRIPTION
# Description

When adding the connector as a dependency without having configured the XRay-Connection, the generation of the Testerra-Report will fail with a null-pointer exception. This PR adds a check so that an error is written to the logs instead.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
